### PR TITLE
alpine-mariadbイメージのMariaDBのバージョンを10.4に固定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
                 max-size: 10m
 
     mysql:
-        image: yobasystems/alpine-mariadb
+        image: yobasystems/alpine-mariadb:10.4.17-arm32v7
         volumes:
             - mysql-db:/var/lib/mysql
         environment:


### PR DESCRIPTION
お世話になっております。

こちらの記事

[Raspberry Pi 4とdocker-mirakurun-epgstationで録画サーバーを構築する (2021年4月版) - 酢ろぐ！](https://blog.ch3cooh.jp/entry/2021/04/06/200732#Docker-Compose%E3%81%AE%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB)

を読んでいた所、一点詰まった部分があったため、微修正ですが、念の為共有とプルリクエストを送らせていただきます。

## 内容

[yobasystems/alpine-mariadb](https://github.com/yobasystems/alpine-mariadb)
の最新イメージでは現在MariaDBは10.5となっていますが、EPGStationが期待するバージョンは10.4のため、
この状態で起動すると、コンソールに"check db"と表示されたままループが行われます。

## 修正点

yobasystems/alpine-mariadbにタグを付与しました。
これにより、MariaDBが10.4だった時のイメージを取得し、コンソールのループは消え、動作を確認しました。